### PR TITLE
Made LangRegistry much sexier internally.

### DIFF
--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -1,3 +1,5 @@
+# DevGarden Coding Style
+
 ## Indentation and Braces
 * Tabs must be used for primary indentation, and spaces for alignment.
 * If a statement spans multiple lines, each line must have exactly the same number of tabs as the opening line.
@@ -6,7 +8,7 @@
 * Braces may be either on their own line or at the end of a line.
 * Please don't put spaces before parentheses unless aligning code.
 * Empty lines may be used to better group statements or declarations in code.
-* All files should have a single empty line at the end, where possible.
+* All files should have a single empty line at the end.
 
 ## Naming
 * Macro names and constants should be `UPPER_CASE`.
@@ -22,15 +24,15 @@
 * #include statements should be grouped by library, i.e. program includes should not be mixed with Qt includes.
 
 ## Portability
-* All code must compile using `-pedantic -std=c++14` on clang 3.5 and g++ 4.9.2.
-* Written code should generally not rely on language extensions that are not disabled by -pedantic.
+* All code must compile using `-pedantic-errors -std=c++14` on clang 3.5 and g++ 6.1.
+* Written code should generally not rely on language extensions that are not disabled by -pedantic-errors.
 * Prefer cross-platform solutions offered by Qt over platform-specific options.
 * Platform-specific code must always be wrapped in an #ifdef block using macros in envmacro.h. No exceptions.
 
 ## C++ Features
-* No `using` constructs are to be used, unless they are in a class declaration, or are used for type aliasing, i.e. `using StringMap = std::map<QString,QString>`
-* No exception throwing.
-* No exception handling except in the same scope.
+* No `using` constructs are to be used, unless they are in a class declaration or are used for type aliasing, i.e. `using StringMap = std::map<QString,QString>`
+* Do not throw exceptions except from constructors where there is a failure that would render the object unusable.
+* Do not use catch(...) blocks without rethrowing the exception.
 * Classes should be declared using class rather than struct. Struct should be preferred for POD.
 * Prefer const variables over macro constants.
 * Prefer std::unique_ptr for the ownership of objects over raw pointers.
@@ -59,4 +61,4 @@
 * Do not push to devel, if avoidable (especially TheRabbitologist).
 * Each contributor should create their own personal branch to push to, and send pull requests into devel when their code is ready.
 * Rebasing is discouraged.
-* Code in personal branches may not compile.
+* Code in personal branches may not compile. Code in the development branch should compile. Code in the master branch must compile.

--- a/src/async/asyncwatcher.cpp
+++ b/src/async/asyncwatcher.cpp
@@ -1,5 +1,7 @@
 #include "asyncwatcher.h"
 
+#include <algorithm>
+
 size_t AsyncWatcher::insert(std::atomic_flag* flag, std::function<void()> func) {
 	bool stahp = stop();
 	auto it = std::find_if(triggers.begin(),triggers.end(),

--- a/src/async/taskchain.h
+++ b/src/async/taskchain.h
@@ -8,19 +8,21 @@
 
 class TaskChain {
 public:
+	using Ref = std::unique_ptr<TaskChain>;
 	using Callback = std::function<bool(const std::atomic_bool&)>;
 	static Callback wrap(std::function<void()> call);
 	static Callback wrap(std::function<bool()> call);
 private:
-	std::unique_ptr<TaskChain> pass_, fail_;
+	Ref pass_, fail_;
 	QString name_;
 protected:
 	Callback task_;
 public:
+
 	TaskChain(const QString& name, Callback task) :
-		task_(task), pass_(nullptr), fail_(nullptr), name_(name) {};
+		task_(task), pass_(nullptr), fail_(nullptr), name_(name) {}
 	TaskChain(const QString& name, Callback task, TaskChain* pass, TaskChain* fail) :
-		task_(task), pass_(pass), fail_(fail), name_(name) {};
+		task_(task), pass_(pass), fail_(fail), name_(name) {}
 	TaskChain(const QString& name, Callback task, TaskChain* next, bool onPass = true) :
 		task_(task), name_(name)
 		{(onPass?pass_:fail_).reset(next);}

--- a/src/dgcontroller.cpp
+++ b/src/dgcontroller.cpp
@@ -240,7 +240,8 @@ QString DGController::getFormattedFileInfo() {
 		filestat = filestat.prepend(" - ");
 	else if(!fc->isCurrSaved())
 		filestat = " - Unsaved";
-	return (filename.isEmpty()?"":(filename+" - ")) + (!fc->getCurrLang().isEmpty()?(fc->getCurrLang()+" - "):"") +
+    const auto langname = lr->getHumanName(fc->getCurrLang());
+	return (filename.isEmpty()?"":(filename+" - ")) + (!langname.isEmpty()?(langname+" - "):"") +
 						QString::number(lines) + (lines==1?" line":" lines")
 						+ filestat + ' ';
 }

--- a/src/envmacros.h
+++ b/src/envmacros.h
@@ -50,3 +50,23 @@
 #else
 	#define DG_ENV "Unknown"
 #endif
+
+#if defined(DG_ENV_MACOS)
+	#define DG_CONFIG_PREFIX_GLOBAL "/Library/Application Support/"
+	#define DG_CONFIG_PREFIX_LOCAL  "Library/Application Support/"
+#elif defined(DG_ENV_WINDOZE)
+	#define DG_CONFIG_PREFIX_GLOBAL "ProgramData/"
+	#define DG_CONFIG_PREFIX_LOCAL  "AppData/Roaming/"
+#elif defined(DG_ENV_UNIX)
+	#define DG_CONFIG_PREFIX_GLOBAL "/usr/share/"
+#if defined(DG_ENV_LINUX)
+	#define DG_CONFIG_PREFIX_LOCAL  ".local/share/"
+#else
+	#define DG_CONFIG_PREFIX_LOCAL  "."
+	#define DG_CONFIG_PREFIX_LOCAL_NOCD
+#endif
+#else
+	#define DG_CONFIG_PREFIX_GLOBAL "/"
+	#define DG_CONFIG_PREFIX_LOCAL  ""
+	#define DG_CONFIG_PREFIX_LOCAL_NOCD
+#endif

--- a/src/filesys/dgfilecache.cpp
+++ b/src/filesys/dgfilecache.cpp
@@ -31,7 +31,7 @@ QTextDocument* DGFileCache::set(const QFileInfo& fi) {
 			fl->setStateUpdateCallback(std::bind(&DGFileCache::onLoaderUpdate,this,current));
 			current->second.setFileLoader(fl);
 
-			current->second.setLang(&lr.getLang(fi));
+			current->second.setLang(lr.getLang(fi));
 			current->second.load();
 		} else
 			current = data.emplace("",FileData()).first;
@@ -55,7 +55,7 @@ bool DGFileCache::saveCurrent() {
 		fl->setStateUpdateCallback(std::bind(&DGFileCache::onLoaderUpdate,this,current));
 		current->second.setFileLoader(fl);
 
-		current->second.setLang(&lr.getLang(f));
+		current->second.setLang(lr.getLang(f));
 		current->second.save();
 		tryClose(old);
 		return true;

--- a/src/filesys/dgfilecache.h
+++ b/src/filesys/dgfilecache.h
@@ -30,9 +30,9 @@ public:
 	inline void bindController(DGController* dgc) {ctrl = ctrl?ctrl:dgc;}
 
 	inline size_t  getCountLoaded() {return data.size();}
-	inline QTextDocument* getCurrDoc()     {return current->second.getDocument();}
-	inline const QString& getCurrLang()    {return current->second.getLang();}
-	inline const QString& getCurrPath()    {return current->first;}
+	inline QTextDocument* getCurrDoc()        {return current->second.getDocument();}
+	inline LangRegistry::LangID getCurrLang() {return current->second.getLang();}
+	inline const QString& getCurrPath()       {return current->first;}
 	QString getCurrStatus();
 
 	inline bool isCurrSaved()   {return current->second.isSaved();}

--- a/src/filesys/dgprojectinfo.cpp
+++ b/src/filesys/dgprojectinfo.cpp
@@ -55,9 +55,9 @@ void DGProjectInfo::catalog(const LangRegistry& lr, const QDir& dir, bool recurs
 			catalog(lr,entry.absoluteDir(),true);
 		else {
 			if(!recursive) {
-				const QString& lang = lr.getLang(entry);
-				if(!lang.isEmpty() && lr.isBuildSys(lang))
-					targets.emplace("default-"+lang, Target(lr, entry));
+				LangRegistry::LangID lang = lr.getLang(entry);
+				if(lr.isBuildSys(lang))
+					targets.emplace("default-"+lr.getHumanName(lang), Target(lr, entry));
 				//May do other searching of the root directory.
 			}
 		}

--- a/src/filesys/dgprojectloader.h
+++ b/src/filesys/dgprojectloader.h
@@ -5,6 +5,7 @@
 
 #include <vector>
 #include <map>
+#include <memory>
 
 #include <QFileInfo>
 
@@ -15,7 +16,7 @@ class QStringList;
  * @brief Loads, stores, and manages all projects' metadata.
  */
 class DGProjectLoader {
-public: using ProjectListType = std::vector<DGProjectInfo*>;
+public: using ProjectListType = std::vector<std::unique_ptr<DGProjectInfo>>;
 private:
 	ProjectListType projs;
 	ProjectListType::iterator current;

--- a/src/filesys/filedata.h
+++ b/src/filesys/filedata.h
@@ -8,8 +8,7 @@
 #include <QPlainTextDocumentLayout>
 
 #include "../consts.h"
-
-class LangRegistry;
+#include "../langregistry.h"
 
 class FileData {
 	std::unique_ptr<FileLoader> fl;
@@ -17,12 +16,10 @@ class FileData {
 	bool autoclose;
 	size_t ref_count;
 	bool saved;
-	const QString* lang;
+	LangRegistry::LangID lang;
 public:
-	FileData() : doc(new QTextDocument), saved(false) {
-		ref_count = 1;
+    FileData() : doc{new QTextDocument}, ref_count{1}, saved{false}, lang{LangRegistry::ID_UNKNOWN} {
 		doc->setDocumentLayout(new QPlainTextDocumentLayout(doc.get()));
-		lang = &dg_consts::STRING_EMPTY;
 	}
 	FileData(FileData&& fd) {
 		fl.reset(fd.fl.release());
@@ -47,11 +44,11 @@ public:
 	bool save();
 	inline bool isSaved() {return saved;}
 
-	inline void setLang(const QString* lname) {lang = lname;}
+	inline void setLang(LangRegistry::LangID lid) {lang = lid;}
 
 	inline QTextDocument* getDocument() {return doc.get();} //Don't you dare free this.
 	inline QTextDocument* releaseDocument() {return doc.release();} //Don't you dare free this.
-	inline const QString& getLang() {return *lang;}
+	inline LangRegistry::LangID getLang() {return lang;}
 	bool operator<(const QString& d);
 	bool operator<(const FileData& d);
 	void markUnsaved() {saved = false;}

--- a/src/langregistry.cpp
+++ b/src/langregistry.cpp
@@ -12,45 +12,54 @@
 
 const QString LangRegistry::DIR = "config/lang";
 
-const QRegExp LangRegistry::FILEEXT_PATTERN = QRegExp("[a-zA-Z0-9_]\\.");
-
 using namespace dg_consts;
 
 QString LangRegistry::getFileExt(const QString& filename) {
-	return filename.section(FILEEXT_PATTERN,-1);
+    auto str = dg_utils::qsExtract(filename);
+    auto slash = str.find_last_of('/');
+    auto dot   = str.find_last_of('.');
+    if(dot >= str.size()-1) //includes npos, >= to account for a dot at the end.
+        return "";
+    if(slash != std::string::npos && slash > dot)
+        return "";
+    return QString(str.substr(dot+1).c_str());
 }
 
 /**
  * @brief Get the corresponding language for a file.
  */
-const QString& LangRegistry::getLang(const QFileInfo& file) const {
+LangRegistry::LangID LangRegistry::getLang(const QFileInfo& file) const {
 	auto it = filenames.find(file.fileName());
 	if(it == filenames.end()) {
-		it = fileexts.find(getFileExt(file.fileName()));
-		if(it == filenames.end())
-			return dg_consts::STRING_EMPTY;
+		it = fileexts.find(file.completeSuffix());
+		if(it == fileexts.end())
+			return LangRegistry::ID_UNKNOWN;
 	}
-	return it->second.lang;
+	return (it->second->lang)-cache_langentries.data();
 }
 
 LangRegistry::LangRegistry() {
-	std::set<QString> langset = dg_utils::getConfigDirs(LangRegistry::DIR.toStdString().c_str());
+	std::set<QString> langset = dg_utils::getConfigDirs(LangRegistry::DIR.toLocal8Bit().data());
 	if(langset.empty()) {
 		std::cerr << "Failed to find language directories!" << std::endl;
 		return;
 	}
 	ConfigEntry* ie;
+    cache_langentries.reserve(langset.size());
 	for(const QString& lang : langset) {
 		std::unique_ptr<QFile> f{dg_utils::getUtilityFileRead(LangRegistry::DIR+'/'+lang+"/properties.conf")};
 		if(f != nullptr) {
 			ConfigFile cf(*f);
-			LangEntry le;
-			QString interpreter;
+            cache_langentries.push_back({});
+			LangEntry* le = &cache_langentries.back();
+            QString interpreter("");
 			if((ie = cf.at("name")))
-				le.name = ie->getData(0)->mid(5);
+				le->name = ie->getData(0)->mid(5);
+            else
+                le->name = lang;
 			if((ie = cf.at("build-sys"))) {
 				if(ie->split() >= 2)
-					le.buildsys = (STRING_DIR_BUILD+lang+'/'+*ie->getData(1)).mid(1);
+					le->buildsys = (STRING_DIR_BUILD+lang+'/'+*ie->getData(1)).mid(1);
 			}
 			if((ie = cf.at("interpreter-external"))) {
 				if(ie->split() >= 2)
@@ -60,25 +69,24 @@ LangRegistry::LangRegistry() {
 				if(ie->split() >= 2)
 					interpreter = '%'+*ie->getData(1);
 			}
-			langs.insert(std::make_pair(lang,le));
+            langs.insert(std::make_pair(lang,le));
 			ConfigFile::Values* fe;
 			const QString table[] = {"file-names", "file-exts", ""};
-			for(size_t n = 0; !table[n].isEmpty(); ++n) {
-				if(!(fe = cf.get(table[n])))
+			for(size_t isext = 0; !table[isext].isEmpty(); ++isext) {
+				if(!(fe = cf.get(table[isext])))
 					continue;
+                auto it = cache_fileentries.emplace(le,std::move(interpreter)).first;
 				for(ConfigEntry* ce : *fe) {
 					size_t e = ce->split();
 					for(size_t i = 1; i < e; ++i) {
 						const QString* ext = ce->getData(i);
-						if(getBindMap(n).count(*ext))
-							std::cout << "Languages '" << fileexts.at(*ext).lang.toStdString()
-									  << "' and '" << lang.toStdString() << "' use " << table[n].toStdString()
+                        auto& bindmap = getBindMap(isext);
+						if(bindmap.count(*ext))
+							std::cout << "Languages '" << fileexts.at(*ext)->lang->name.toStdString()
+									  << "' and '" << lang.toStdString() << "' use " << table[isext].toStdString()
 									  << " entry '" << ext->toStdString() << "'. Preferring the former." << std::endl;
-						else {
-							FileEntry ee(lang);
-							ee.interpreter = interpreter;
-							getBindMap(n).insert(std::make_pair(*ext,ee));
-						}
+						else
+                            bindmap.insert(std::make_pair(*ext,&(*it)));
 					}
 				}
 			}
@@ -87,56 +95,50 @@ LangRegistry::LangRegistry() {
 	}
 }
 
-std::set<QString> LangRegistry::makeBuildSysSet() const {
-	std::set<QString> retval;
+std::set<LangRegistry::LangID> LangRegistry::makeBuildSysSet() const {
+	std::set<LangID> retval;
 	for(auto& pair : langs) {
-		if(!pair.second.buildsys.isEmpty())
-			retval.insert(pair.first);
+		if(!pair.second->buildsys.isEmpty())
+			retval.insert(pair.second-cache_langentries.data());
 	}
 	return retval;
 }
 
-const QString& LangRegistry::getHumanName(const QString& lang) const {
-	auto it = langs.find(lang);
-	if(it != langs.end()) {
-		if(it->second.name.isEmpty())
-			return it->first;
-		return it->second.name;
-	}
-	return STRING_EMPTY;
+QString LangRegistry::getHumanName(LangID id) const {
+    if(id >= cache_langentries.size())
+        return STRING_EMPTY;
+    return cache_langentries[id].name;
 }
 
-bool LangRegistry::isBuildSys(const QString& lang) const {
-	if(knowsLang(lang))
-		return !langs.at(lang).buildsys.isEmpty();
-	return false;
+bool LangRegistry::isBuildSys(LangID id) const {
+    if(id >= cache_langentries.size())
+        return false;
+	return !cache_langentries[id].buildsys.isEmpty();
 }
 
-const QString& LangRegistry::getBuildSys(const QString& lang) const {
-	if(knowsLang(lang))
-		return langs.at(lang).buildsys;
-	return STRING_EMPTY;
+QString LangRegistry::getBuildSys(LangID id) const {
+    return cache_langentries.at(id).buildsys;
 }
 
-const QString& LangRegistry::getLang(const QString& name, bool isext) const {
+LangRegistry::LangID LangRegistry::getLang(const QString& name, bool isext) const {
 	if(knowsFile(name,isext))
-		return getBindMapConst(isext).at(name).lang;
-	return STRING_EMPTY;
+		return (getBindMapConst(isext).at(name)->lang)-cache_langentries.data();
+	return LangRegistry::ID_UNKNOWN;
 }
 
 bool LangRegistry::ready(const QString& name, bool isext) const {
 	if(knowsFile(name,isext))
-		return langs.count(getBindMapConst(isext).at(name).lang);
+		return langs.count(getBindMapConst(isext).at(name)->lang->name);
 	return false;
 }
 
 bool LangRegistry::add(const QStringList& langs) {
 	bool issues = false;
 	for(const QString& lang : langs) {
-		if(!this->langs.at(lang).refs) {
+		if(!this->langs.at(lang)->refs) {
 			//TODO: Loading code.
 		}
-		++this->langs.at(lang).refs;
+		++this->langs.at(lang)->refs;
 	}
 	return issues;
 }
@@ -144,9 +146,9 @@ bool LangRegistry::add(const QStringList& langs) {
 bool LangRegistry::rem(const QStringList& langs) {
 	bool deloaded = false;
 	for(const QString& lang : langs) {
-		bool load = this->langs.at(lang).refs;
+		bool load = this->langs.at(lang)->refs;
 		if(load) {
-			load = --this->langs.at(lang).refs;
+			load = --this->langs.at(lang)->refs;
 			if(!load) {
 				deloaded = true;
 				//TODO: Unloading code.
@@ -159,7 +161,7 @@ bool LangRegistry::rem(const QStringList& langs) {
 QString LangRegistry::getInterpreter(const QString& name, bool isext) const {
 	if(!hasInterpreter(name,isext))
 		return "";
-	LangRegistry::FileEntry extinfo = getBindMapConst(isext).at(name);
+	LangRegistry::FileEntry extinfo = *(getBindMapConst(isext).at(name));
 	if(extinfo.interpreter.at(0) == '@')
 		return extinfo.interpreter.mid(1);
 	else if(extinfo.interpreter.at(0) == '%') {
@@ -183,11 +185,11 @@ QString LangRegistry::getInterpreter(const QFileInfo& fi) const {
 }
 
 bool LangRegistry::hasInterpreter(const QString& name, bool isext) const {
-	try {
-		return !getBindMapConst(isext).at(name).interpreter.isEmpty();
-	} catch(...) {
-		return false;
-	}
+	const auto& map = getBindMapConst(isext);
+    auto it = map.find(name);
+    if(it != map.cend())
+		return it->second->interpreter.isEmpty();
+	return false;
 }
 
 bool LangRegistry::hasInterpreter(const QFileInfo& fi) const {

--- a/src/langregistry.h
+++ b/src/langregistry.h
@@ -1,6 +1,7 @@
 #ifndef LANGREFCOUNT_H
 #define LANGREFCOUNT_H
 
+#include <vector>
 #include <map>
 #include <set>
 #include <QString>
@@ -12,27 +13,37 @@ class QFileInfo;
  */
 class LangRegistry {
 	static const QString DIR;
-	static const QRegExp FILEEXT_PATTERN;
-
+public:
 	struct LangEntry {
-		LangEntry() {refs = 0; buildsys = "";}
+        LangEntry() : refs{0}, buildsys(""), name("") {}
 		size_t refs;
 		QString buildsys;
 		QString name;
 	};
 	struct FileEntry {
-		explicit FileEntry(const QString& lang) {this->lang = lang;}
-		QString lang;
+		LangEntry* lang;
 		QString interpreter;
+        bool operator<(const FileEntry& b) const {return lang<b.lang || interpreter<b.interpreter;} //WARNING: Voodoo.
+        FileEntry(LangEntry* language, const QString& interp = "") : lang{language}, interpreter(interp) {}
 	};
+    using LangID = size_t;
 
-	std::map<QString,FileEntry> fileexts;
-	std::map<QString,FileEntry> filenames;
-	std::map<QString,LangEntry> langs;
+    static constexpr LangID ID_UNKNOWN = static_cast<LangID>(-1);
 
-	inline std::map<QString,FileEntry>&        getBindMap      (bool isext)        {return isext?fileexts:filenames;}
-	inline const std::map<QString,FileEntry>&  getBindMapConst (bool isext) const  {return isext?fileexts:filenames;}
+private:
+    using FileMap = std::map<QString,const FileEntry*>;
+
+    std::set<FileEntry>    cache_fileentries;
+    std::vector<LangEntry> cache_langentries;
+
+	FileMap fileexts;
+	FileMap filenames;
+    std::map<QString,LangEntry*> langs;
+
+	inline       FileMap& getBindMap     (bool isext)       {return isext?fileexts:filenames;}
+	inline const FileMap& getBindMapConst(bool isext) const {return isext?fileexts:filenames;}
 public:
+
 	static QString getFileExt(const QString& filename);
 
 	LangRegistry();
@@ -47,17 +58,17 @@ public:
 	 * This name is meant to be human-friendlier, and should be used in GUI elements or messages.
 	 * It should also be passed through tr() first.
 	 */
-	const QString& getHumanName(const QString& lang) const;
+	QString getHumanName(LangID id) const;
 
 	/**
 	 * @brief Get the corresponding language for a file.
 	 */
-	const QString& getLang(const QFileInfo& file) const;
+	LangID getLang(const QFileInfo& file) const;
 
 	/**
 	 * @brief Get the corresponding language for a file extension or name
 	 */
-	const QString& getLang(const QString& name, bool isext = true) const; //Default true for teenagers.
+	LangID getLang(const QString& name, bool isext = true) const; //Default true for teenagers.
 
 	/**
 	 * @brief Check if an interpreter exists for a given language.
@@ -73,17 +84,17 @@ public:
 	/**
 	 * @brief Return whether or not a language describes files for a build system.
 	 */
-	bool isBuildSys(const QString& lang) const;
+	bool isBuildSys(LangID id) const;
 
 	/**
 	 * @brief Get the name build system invocation script in %tools/build/<lang>
 	 */
-	const QString& getBuildSys(const QString& lang) const;
+	QString getBuildSys(LangID id) const;
 
 	/**
 	 * @brief Gets the set of build systems that LangRegistry recognizes.
 	 */
-	std::set<QString> makeBuildSysSet() const;
+	std::set<LangID> makeBuildSysSet() const;
 
 	/**
 	 * @brief getInterpreter Get the interpreter for a certain language.
@@ -96,7 +107,7 @@ public:
 	bool add(const QStringList& langs);
 	bool rem(const QStringList& langs);
 
-	inline size_t countRefs(const QString& lang) const {return langs.at(lang).refs;}
+	inline size_t countRefs(LangID lang) const {return cache_langentries.at(lang).refs;}
 	inline size_t countLanguages() const {return langs.size();}
 	inline size_t countBindings() const {return fileexts.size() + filenames.size();}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,15 +32,14 @@ int main(int argc, char **argv) {
 	a.setApplicationName(DG_NAME);
 
 	std::cout << DG_NAME << " v. " <<
-				 DG_VERSION_MAJOR << '.' <<
-				 DG_VERSION_MINOR << '.' <<
-				 DG_VERSION_PATCH << " on " <<
-				 DG_ENV << std::endl;
+                 DG_VERSION_MAJOR << '.' <<
+                 DG_VERSION_MINOR << '.' <<
+                 DG_VERSION_PATCH << " on " <<
+                 DG_ENV << std::endl;
 
-	bool test = false;
 	if(a.arguments().length() == 2 && a.arguments().at(1) == "--selftest") {
 		std::cout << "Begin self-test." << std::endl;
-		test = true;
+		dg_utils::GlobalFlags::setTesting();
 	}
 
 	a.setWindowIcon(QIcon("://icon.png"));
@@ -56,41 +55,41 @@ int main(int argc, char **argv) {
 	ConfigFile f("config/editor.conf");
 
 	std::cout << "Initializing..." << std::endl;
-		if(test) std::cerr << "TEST: init filesystem watcher" << std::endl;
+		DG_EC_SELFTEST_ECHO("init filesystem watcher")
 	QFileSystemWatcher fsw;
 	FileLoaderFS::setFileSystemWatcher(&fsw);
-		if(test) std::cerr << "TEST: init LangRegistry" << std::endl;
+		DG_EC_SELFTEST_ECHO("init LangRegistry")
 	std::unique_ptr<LangRegistry> lr(new LangRegistry);
-		if(test) std::cerr << "TEST: init AsyncWatcher" << std::endl;
+		DG_EC_SELFTEST_ECHO("init AsyncWatcher")
 	std::unique_ptr<AsyncWatcher> aw(new AsyncWatcher);
-		if(test) std::cerr << "TEST: init Executor" << std::endl;
+		DG_EC_SELFTEST_ECHO("init Executor")
 	std::unique_ptr<Executor> exe(new Executor);
-		if(test) std::cerr << "TEST: init FileCache" << std::endl;
+		DG_EC_SELFTEST_ECHO("init FileCache")
 	std::unique_ptr<DGFileCache> fc(new DGFileCache(*lr));
-		if(test) std::cerr << "TEST: init ProjectLoader" << std::endl;
+		DG_EC_SELFTEST_ECHO("TEST: init ProjectLoader")
 	std::unique_ptr<DGProjectLoader> pl(new DGProjectLoader(*lr));
 
 	//Would normally assure correct pluralization here, but these are console status messages.
 	std::cout << "Loaded " << lr->countLanguages() << " languages" << std::endl;
 	std::cout << "Loaded " << lr->countBindings() << " file associations" << std::endl;
 
-		if(test) std::cerr << "TEST: init DGController" << std::endl;
+		DG_EC_SELFTEST_ECHO("TEST: init DGController")
 	DGController* ctrl = new DGController(pl.get(), fc.get(), lr.get(), exe.get());
-		if(test) std::cerr << "TEST: init DGWindow" << std::endl;
+		DG_EC_SELFTEST_ECHO("TEST: init DGWindow")
 	std::unique_ptr<DGWindow>w (new DGWindow(ctrl, *lr, exe.get()));
 	ctrl->setView(w.get());
 	fc->bindController(ctrl);
 	w->configure(f);
 	DGStyle::applyStyle(&a);
 
-	if(!test) {
+	DG_EC_SELFTEST_ECHO("PASS: init")
+	else {
 		std::cout << "Finished loading " << DG_NAME << std::endl;
 		w->show();
 		int retval = a.exec();
 		delete ctrl;
 		return retval;
 	}
-	std::cerr << "PASS: init" << std::endl;
 	//TODO: More tests.
 	delete ctrl;
 	return 0;

--- a/src/target.h
+++ b/src/target.h
@@ -7,7 +7,6 @@
 #include "consts.h"
 #include "langregistry.h"
 
-class LangRegistry;
 class QDir;
 
 namespace dg_utils {class RunToolAsyncFlags;}
@@ -17,8 +16,9 @@ namespace dg_utils {class RunToolAsyncFlags;}
  */
 class Target {
 	QFileInfo file;
-	QString target, buildsys; //NOTE: target here is not this target's name necessarily.
+	QString target; //NOTE: target here is not this target's name necessarily.
 	const LangRegistry& lr;
+    LangRegistry::LangID buildsys;
 	std::map<QString,QString> vars;
 public:
 	/**

--- a/src/ui/dgcentralwidget.cpp
+++ b/src/ui/dgcentralwidget.cpp
@@ -37,9 +37,9 @@ DGCentralWidget::DGCentralWidget(DGController* ctrl, Executor* exe, QWidget *par
 
 QPushButton* DGCentralWidget::makeButton(const QString& txt, int width, int height) {
 	auto* retval = new QPushButton(tr(txt.toLocal8Bit()));
-	retval->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-	retval->setMinimumSize(width, height);
-	retval->setMaximumSize(width, height);
+	//retval->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+	//retval->setMinimumSize(width, height);
+	//retval->setMaximumSize(width, height);
 	return retval;
 }
 
@@ -48,7 +48,7 @@ void DGCentralWidget::createWidgets(Executor* exe)
 	leftBar = new QWidget;
 
 	// Project Directory Tree
-	projectDirModel = new QFileSystemModel;
+	projectDirModel = new QFileSystemModel(this);
 	projectDirModel->setFilter(QDir::NoDotAndDotDot | QDir::AllDirs);
 	projectDirModel->setRootPath(QCoreApplication::applicationDirPath());
 
@@ -87,13 +87,13 @@ void DGCentralWidget::createWidgets(Executor* exe)
 	fileInfo->setAlignment(Qt::AlignRight);
 
 	//Command box.
-	cmdLine = new QLineEdit();
+	cmdLine = new QLineEdit;
 	cmdLine->setPlaceholderText("Enter command...");
 
 	taskStatusLabel = new DGTaskStatusLabel(exe);
 
 	// Bottom Bar
-	rightBarLayout = new QVBoxLayout();
+	rightBarLayout = new QVBoxLayout;
 	for(size_t i = 0; i < BUTTON_LOWER_NAMES.size(); ++i) {
 		auto* button = makeButton(BUTTON_LOWER_NAMES[i], 72, 32);
 		buttonsSide.emplace(static_cast<ButtonIdLower>(i), button);
@@ -125,7 +125,7 @@ void DGCentralWidget::createLayout()
 	leftSideLayout->addWidget(leftSplitter);
 	leftSideLayout->update();
 
-	editorLayout = new QVBoxLayout();
+	editorLayout = new QVBoxLayout;
 	editorLayout->setSpacing(4);
 	editorLayout->addWidget(fileInfo);
 	editorLayout->addWidget(textEditor);
@@ -145,7 +145,7 @@ void DGCentralWidget::createLayout()
 	rightSideLayout->addLayout(bottomBarLayout);
 
 	// Main Layout (Combination of all child layouts)
-	mainSplitter = new QSplitter(Qt::Horizontal,this);
+	mainSplitter = new QSplitter(Qt::Horizontal);
 	leftBar->setHidden(true);
 	temp = new QWidget;
 	leftBar->setLayout(leftSideLayout);
@@ -161,13 +161,13 @@ void DGCentralWidget::createLayout()
 }
 
 void DGCentralWidget::setupConnections() {
-	this->connect(mainSplitter,	    SIGNAL(splitterMoved(int,int)),             SLOT(resizeDirView()));
-	this->connect(projectDirView,   SIGNAL(expanded(QModelIndex)),              SLOT(resizeDirView()));
-	this->connect(projectDirView,   SIGNAL(collapsed(QModelIndex)),             SLOT(resizeDirView()));
-	this->connect(projectComboBox,  SIGNAL(currentIndexChanged(int)),           SLOT(changeProject(int)));
-	this->connect(ctrl,             SIGNAL(sigProjectListChanged()),            SLOT(updateProjectList()));
-	this->connect(ctrl,             SIGNAL(sigProjectClosed()),                 SLOT(shrinkProjectList()));
-	this->connect(projectDirView,   SIGNAL(clicked(const QModelIndex&)),        SLOT(changeFile(const QModelIndex&)));
+	this->connect(mainSplitter,		SIGNAL(splitterMoved(int,int)),			 SLOT(resizeDirView()));
+	this->connect(projectDirView,   SIGNAL(expanded(QModelIndex)),			  SLOT(resizeDirView()));
+	this->connect(projectDirView,   SIGNAL(collapsed(QModelIndex)),			 SLOT(resizeDirView()));
+	this->connect(projectComboBox,  SIGNAL(currentIndexChanged(int)),		   SLOT(changeProject(int)));
+	this->connect(ctrl,			 SIGNAL(sigProjectListChanged()),			SLOT(updateProjectList()));
+	this->connect(ctrl,			 SIGNAL(sigProjectClosed()),				 SLOT(shrinkProjectList()));
+	this->connect(projectDirView,   SIGNAL(clicked(const QModelIndex&)),		SLOT(changeFile(const QModelIndex&)));
 
 	connect(buttonsSide.at(DGCentralWidget::BUILD), SIGNAL(pressed()), ctrl, SLOT(build()));
 	connect(buttonsSide.at(DGCentralWidget::REBUILD), SIGNAL(pressed()), ctrl, SLOT(rebuild()));

--- a/src/ui/dgwindow.cpp
+++ b/src/ui/dgwindow.cpp
@@ -91,10 +91,10 @@ void DGWindow::createMenuActions(const LangRegistry& lr) {
 
 	menuBuild.reset(new DGMenu(menuBar()->addMenu(tr("&Build"))));
 	menuBuildInit.reset(menuBuild->addMenu("Create Build System"));
-	std::set<QString> bses = lr.makeBuildSysSet();
+	auto bses = lr.makeBuildSysSet();
 	if(!bses.empty()) {
-		for(const QString& bs : bses)
-			menuBuildInit->addAction(bs,lr.getHumanName(bs)+"...");
+		for(const auto& bs : bses)
+            menuBuildInit->addAction(QString("buildsys-")+bs,lr.getHumanName(bs)+"...");
 	} else
 		menuBuildInit->getMenu().setDisabled(true);
 
@@ -208,8 +208,8 @@ void DGWindow::disableBuildButtons(bool disable) {
 	menuBuild->getAction("Abort Build")->setDisabled(!disable);
 }
 
-void DGWindow::zoomOut()    {this->centralWidget->getEditor()->fontSizeDec();}
-void DGWindow::zoomIn()     {this->centralWidget->getEditor()->fontSizeInc();}
+void DGWindow::zoomOut()	{this->centralWidget->getEditor()->fontSizeDec();}
+void DGWindow::zoomIn()	 {this->centralWidget->getEditor()->fontSizeInc();}
 void DGWindow::zoomReset()  {this->centralWidget->getEditor()->fontSizeRes();}
 
 void DGWindow::nullSlot() {}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,6 +12,12 @@
 
 namespace dg_utils {
 
+std::string qsExtract(const QString& in) {
+    return std::string{in.toUtf8().constData()};
+}
+
+bool GlobalFlags::self_test = false;
+
 QFileInfo* getUtilityFile(const QString& name) {
 	QFileInfo* f = new QFileInfo();
 	f->setFile(QDir::home().path()+'/'+DG_CONFIG_PREFIX_LOCAL+DG_NAME+'/'+name);

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,26 +7,6 @@
 #include <vector>
 #include <mutex>
 
-#if defined(DG_ENV_MACOS)
-	#define DG_CONFIG_PREFIX_GLOBAL "/Library/Application Support/"
-	#define DG_CONFIG_PREFIX_LOCAL  "Library/Application Support/"
-#elif defined(DG_ENV_WINDOZE)
-	#define DG_CONFIG_PREFIX_GLOBAL "ProgramData/"
-	#define DG_CONFIG_PREFIX_LOCAL  "AppData/Roaming/"
-#elif defined(DG_ENV_UNIX)
-    #define DG_CONFIG_PREFIX_GLOBAL "/usr/share/"
-#if defined(DG_ENV_LINUX)
-    #define DG_CONFIG_PREFIX_LOCAL  ".local/share/"
-#else
-    #define DG_CONFIG_PREFIX_LOCAL  "."
-    #define DG_CONFIG_PREFIX_LOCAL_NOCD
-#endif
-#else
-	#define DG_CONFIG_PREFIX_GLOBAL "/"
-	#define DG_CONFIG_PREFIX_LOCAL  ""
-	#define DG_CONFIG_PREFIX_LOCAL_NOCD
-#endif
-
 class QFile;
 class QFileInfo;
 class QDir;
@@ -36,6 +16,15 @@ class QTextStream;
 #include <atomic>
 
 namespace dg_utils {
+
+std::string qsExtract(const QString& in);
+
+class GlobalFlags {
+	static bool self_test;
+public:
+	static bool isTesting()  {return self_test;}
+	static bool setTesting(bool newValue = true) {bool old = newValue; std::swap(old, self_test); return old;}
+};
 
 class RunToolAsyncFlags;
 
@@ -75,5 +64,7 @@ public:
 };
 
 }
+
+#define DG_EC_SELFTEST_ECHO(OUTPUT) if(dg_utils::GlobalFlags::isTesting()) {std::cerr << "SELF-TEST: " << OUTPUT << std::endl;}
 
 #endif // CONFIGLOADER_H


### PR DESCRIPTION
LangIDs are now passed around to refer to specific languages rather than QStrings representing their names.
Greatly reduced the amount of lookups required to get language information.
Theoretically reduced the memory footprint of file extension association.
LangRegistry now considers the whole suffix (i.e. tar.gz) for language matching.
NOTE: The segfault on cleanup is known about.